### PR TITLE
fix(ci): add setup steps to test job in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,18 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: cv-app
+
       - name: Run unit tests
         run: npm test
         working-directory: cv-app


### PR DESCRIPTION
The test job in the GitHub workflow was failing because it was missing the steps to checkout the code, set up Node.js, and install dependencies. This change adds the missing steps to the test job, ensuring that the test environment is properly initialized before running the tests.